### PR TITLE
Update github actions to include full previews and nightly tests

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,38 @@
+name: Build Website Cache
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-cache:
+    name: Build Website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-lectures
+      - name: Checkout QuantEcon theme
+        uses: actions/checkout@v2
+        with:
+          repository: QuantEcon/lecture-python-programming.theme
+          token: ${{ secrets.ACTIONS_PAT }}
+          path: theme/lecture-python-programming.theme
+      - name: Cache Website Build Folder
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: _build
+          key: cache-sphinx
+      - name: Build Website files
+        shell: bash -l {0}
+        run: |
+          make website THEMEPATH=theme/lecture-python-programming.theme
+          ls _build/website/jupyter_html/*

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Execution and Link Testing (Nightly)
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  coverage:
+    name: Run Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-lectures
+      - name: Run Execution Tests
+        shell: bash -l {0}
+        run: make coverage
+  linkchecker:
+    name: Run linkchecker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-lectures
+      - name: Run Linkchecker
+        shell: bash -l {0}
+        run: make linkcheck

--- a/scripts/execution-test.sh
+++ b/scripts/execution-test.sh
@@ -1,19 +1,35 @@
 #!/bin/bash
 
+CLEAN_BUILD=false
 MODIFIED_FILES="$1"
 
 RST_FILES=""
 for F in $MODIFIED_FILES
 do
+    if [[ $F == environment.yml ]]
+    then
+        CLEAN_BUILD=true
+        break
+    fi
+    #Extract List of RST Files
     if [[ $F == *.rst ]]
     then
         RST_FILES="$RST_FILES $F"
     fi
 done
+
 echo "List of Changed RST Files: $RST_FILES"
-if [ -z "$RST_FILES" ]; then
+echo "Clean Build Requested: $CLEAN_BUILD"
+
+if [ "$CLEAN_BUILD" = true ]
+then
+    echo "Running Clean Build"
+    make coverage
+elif [ -z "$RST_FILES" ]
+then
     echo "No RST Files have changed -- nothing to do in this PR"
 else
     RST_FILES="$RST_FILES source/rst/index_toc.rst"
+    echo "Running Selecting Build with: $RST_FILES"
     make coverage FILES="$RST_FILES"
 fi


### PR DESCRIPTION
This PR setups up:

1. nightly builds with `make coverage` and `make linkcheck` for all `rst` files
1. adds site cache for `_build/website/jupyter_html` for full previews
1. adds full rebuilds for changes to `environment.yml`

- [x] check if `cache` for `_build/website_jupyter_html` is reset on `push` to master