### PR TITLE
[Github Actions] add support for fork PRs to build preview with public theme

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,6 +22,7 @@ jobs:
         id: files
         uses: jitterbit/get-changed-files@v1
       - name: Checkout QuantEcon theme
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v2
         with:
           repository: QuantEcon/lecture-python-programming.theme
@@ -40,7 +41,7 @@ jobs:
       - name: Build website files
         shell: bash -l {0}
         run: |
-          bash scripts/build-website.sh "${{ steps.files.outputs.added_modified }}"
+          bash scripts/build-website.sh "${{ steps.files.outputs.added_modified }}" "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
       - name: Preview Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.0
         if: env.BUILD_NETLIFY == 'true'

--- a/scripts/build-website.sh
+++ b/scripts/build-website.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MODIFIED_FILES="$1"
+PRIVATE_THEME=$2
 
 RST_FILES=""
 for F in $MODIFIED_FILES
@@ -11,12 +12,17 @@ do
     fi
 done
 echo "List of Changed RST Files: $RST_FILES"
+echo "Building with Private theme: $PRIVATE_THEME"
 if [ -z "$RST_FILES" ]; then
     echo "::set-env name=BUILD_NETLIFY::false"
     echo "No RST Files have changed -- nothing to do in this PR"
 else
     echo "::set-env name=BUILD_NETLIFY::true"
     RST_FILES="$RST_FILES source/rst/index_toc.rst"
-    make website THEMEPATH=theme/lecture-python-programming.theme FILES="$RST_FILES"
+    if [ "$PRIVATE_THEME" = true ]; then
+        make website THEMEPATH=theme/lecture-python-programming.theme FILES="$RST_FILES"
+    else
+        make website FILES="$RST_FILES"
+    fi
     ls _build/website/jupyter_html/*  #Ensure build files are created
 fi


### PR DESCRIPTION
This PR adds Github Action support to build `preview` for forked PRs using the public theme.

These changes have been copied from @mmcky's work in [this PR](https://github.com/QuantEcon/lecture-python/pull/216).