### PR TITLE
[testing] add sphinxcontrib-myst extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -40,6 +40,7 @@ extensions = [
 	'IPython.sphinxext.ipython_console_highlighting',
     # Custom Sphinx Extensions
     'sphinxcontrib.jupyter', 
+    'sphinxcontrib.myst'
 ]
 
 # Retired Extensions but may be useful in Future

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,8 @@ dependencies:
   - networkx
   - sphinx=2.4.4
   - pip:
-    - sphinxcontrib-jupyter 
-    - sphinxcontrib-bibtex 
-    - quantecon 
+    - sphinxcontrib-jupyter
+    - sphinxcontrib-bibtex
+    - git+https://github.com/mmcky/sphinxcontrib-myst.git
+    - quantecon
     - joblib


### PR DESCRIPTION
This PR adds [sphinxcontrib-myst](https://github.com/mmcky/sphinxcontrib-myst/) for further testing to generate `myst` documents. 