### PR TITLE
update pip to conda for quantecon package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,4 @@ dependencies:
   - pip:
     - sphinxcontrib-jupyter 
     - sphinxcontrib-bibtex 
-    - quantecon 
     - joblib

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,8 @@ dependencies:
   - matplotlib
   - networkx
   - sphinx=2.4.4
+  - sympy
+  - scipy
   - pip:
     - sphinxcontrib-jupyter 
     - sphinxcontrib-bibtex 

--- a/source/rst/getting_started.rst
+++ b/source/rst/getting_started.rst
@@ -429,19 +429,19 @@ One library we'll be using is `QuantEcon.py <http://quantecon.org/quantecon-py>`
 You can install `QuantEcon.py <http://quantecon.org/quantecon-py>`__ by
 starting Jupyter and typing
 
-    ``!conda install -c conda-forge quantecon``
+    ``!conda install quantecon``
 
 into a cell.
 
 Alternatively, you can type the following into a terminal
 
-    ``conda install -c conda-forge quantecon``
+    ``conda install quantecon``
 
 More instructions can be found on the `library page <http://quantecon.org/quantecon-py>`__.
 
 To upgrade to the latest version, which you should do regularly, use
 
-    ``conda upgrade -c conda-forge quantecon``
+    ``conda upgrade quantecon``
 
 Another library we will be using is `interpolation.py <https://github.com/EconForge/interpolation.py>`__.
 

--- a/source/rst/getting_started.rst
+++ b/source/rst/getting_started.rst
@@ -420,7 +420,7 @@ Installing Libraries
 
 Most of the libraries we need come in Anaconda.
 
-Other libraries can be installed with ``pip``.
+Other libraries can be installed with ``pip`` or ``conda``.
 
 One library we'll be using is `QuantEcon.py <http://quantecon.org/quantecon-py>`__.
 
@@ -429,26 +429,25 @@ One library we'll be using is `QuantEcon.py <http://quantecon.org/quantecon-py>`
 You can install `QuantEcon.py <http://quantecon.org/quantecon-py>`__ by
 starting Jupyter and typing
 
-
-    ``!pip install --upgrade quantecon``
+    ``!conda install -c conda-forge quantecon``
 
 into a cell.
 
 Alternatively, you can type the following into a terminal
 
-    ``pip install quantecon``
+    ``conda install -c conda-forge quantecon``
 
 More instructions can be found on the `library page <http://quantecon.org/quantecon-py>`__.
 
 To upgrade to the latest version, which you should do regularly, use
 
-    ``pip install --upgrade quantecon``
+    ``conda upgrade -c conda-forge quantecon``
 
 Another library we will be using is `interpolation.py <https://github.com/EconForge/interpolation.py>`__.
 
 This can be installed by typing in Jupyter
 
-    ``!pip install interpolation``
+    ``!conda install -c conda-forge interpolation``
 
 
 

--- a/source/rst/need_for_speed.rst
+++ b/source/rst/need_for_speed.rst
@@ -47,7 +47,7 @@ In addition to what's in Anaconda, this lecture will need
 .. code-block:: ipython
   :class: hide-output
 
-  !pip install --upgrade quantecon
+  !conda install -c conda-forge quantecon
 
 
 

--- a/source/rst/need_for_speed.rst
+++ b/source/rst/need_for_speed.rst
@@ -47,7 +47,7 @@ In addition to what's in Anaconda, this lecture will need
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -c conda-forge quantecon
+  !conda install quantecon
 
 
 

--- a/source/rst/numba.rst
+++ b/source/rst/numba.rst
@@ -13,7 +13,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -c conda-forge quantecon
+  !conda install quantecon
 
 Please also make sure that you have the latest version of Anaconda, since old
 versions are a :doc:`common source of errors <troubleshooting>`.

--- a/source/rst/numba.rst
+++ b/source/rst/numba.rst
@@ -13,7 +13,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !pip install --upgrade quantecon
+  !conda install -c conda-forge quantecon
 
 Please also make sure that you have the latest version of Anaconda, since old
 versions are a :doc:`common source of errors <troubleshooting>`.

--- a/source/rst/parallelization.rst
+++ b/source/rst/parallelization.rst
@@ -13,7 +13,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -c conda-forge quantecon
+  !conda install quantecon
 
 
 Overview

--- a/source/rst/parallelization.rst
+++ b/source/rst/parallelization.rst
@@ -13,7 +13,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !pip install --upgrade quantecon
+  !conda install -c conda-forge quantecon
 
 
 Overview

--- a/source/rst/troubleshooting.rst
+++ b/source/rst/troubleshooting.rst
@@ -35,9 +35,9 @@ You also need to keep the external code libraries, such as `QuantEcon.py
 
 For this task you can either
 
-* use `pip install --upgrade quantecon` on the command line, or
+* use `conda upgrade -c conda-forge quantecon` on the command line, or
 
-* execute `!pip install --upgrade quantecon` within a Jupyter notebook.
+* execute `!conda upgrade -c conda-forge quantecon` within a Jupyter notebook.
 
 If your local environment is still not working you can do two things.
 

--- a/source/rst/troubleshooting.rst
+++ b/source/rst/troubleshooting.rst
@@ -35,9 +35,9 @@ You also need to keep the external code libraries, such as `QuantEcon.py
 
 For this task you can either
 
-* use `conda upgrade -c conda-forge quantecon` on the command line, or
+* use `conda upgrade quantecon` on the command line, or
 
-* execute `!conda upgrade -c conda-forge quantecon` within a Jupyter notebook.
+* execute `!conda upgrade quantecon` within a Jupyter notebook.
 
 If your local environment is still not working you can do two things.
 


### PR DESCRIPTION
**Note:**

There is still a need to introduce `pip` given `pandas-datareader` is a pip install in `pandas.rst` so I have amended `getting_started` to mention both pip and conda. 

source/rst/./getting_started.rst:Other libraries can be installed with ``pip`` or ``conda``.
source/rst/./pandas.rst:    !pip install --upgrade pandas-datareader