### PR TITLE
[FIX] fix rst spacing for nested lists

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           bash scripts/build-website.sh "${{ steps.files.outputs.added_modified }}" "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
       - name: Preview Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1.0
+        uses: nwtgck/actions-netlify@v1.1
         if: env.BUILD_NETLIFY == 'true'
         with:
           publish-dir: './_build/website/jupyter_html'

--- a/environment.yml
+++ b/environment.yml
@@ -1,23 +1,12 @@
 name: qe-lectures
 channels:
   - default
-  - conda-forge
 dependencies:
+  - python=3.7
+  - anaconda=2020.02
   - pip
-  - python
-  - jupyter
-  - jupyterlab
-  - nbconvert
-  - pandoc
-  - pandas
-  - numba
-  - numpy
-  - matplotlib
-  - networkx
-  - sphinx=2.4.4
-  - sympy
-  - scipy
   - pip:
-    - sphinxcontrib-jupyter 
-    - sphinxcontrib-bibtex 
+    - interpolation
+    - sphinxcontrib-jupyter
+    - sphinxcontrib-bibtex
     - joblib

--- a/source/rst/functions.rst
+++ b/source/rst/functions.rst
@@ -234,9 +234,9 @@ We will break this program into two parts:
 
 #. The main part of the program that
 
-    #. calls this function to get data
+   #. calls this function to get data
 
-    #. plots the data
+   #. plots the data
 
 This is accomplished in the next program
 
@@ -302,9 +302,9 @@ Notes
 
 * Notice that equality is tested with the ``==`` syntax, not ``=``.
 
-    * For example, the statement ``a = 10`` assigns the name ``a`` to the value ``10``.
+   * For example, the statement ``a = 10`` assigns the name ``a`` to the value ``10``.
 
-    * The expression ``a == 10`` evaluates to either ``True`` or ``False``, depending on the value of ``a``.
+   * The expression ``a == 10`` evaluates to either ``True`` or ``False``, depending on the value of ``a``.
 
 Now, there are several ways that we can simplify the code above.
 

--- a/source/rst/functions.rst
+++ b/source/rst/functions.rst
@@ -302,9 +302,9 @@ Notes
 
 * Notice that equality is tested with the ``==`` syntax, not ``=``.
 
-   * For example, the statement ``a = 10`` assigns the name ``a`` to the value ``10``.
+  * For example, the statement ``a = 10`` assigns the name ``a`` to the value ``10``.
 
-   * The expression ``a == 10`` evaluates to either ``True`` or ``False``, depending on the value of ``a``.
+  * The expression ``a == 10`` evaluates to either ``True`` or ``False``, depending on the value of ``a``.
 
 Now, there are several ways that we can simplify the code above.
 

--- a/source/rst/getting_started.rst
+++ b/source/rst/getting_started.rst
@@ -519,9 +519,9 @@ Nothing beats the power and efficiency of a good text editor for working with pr
 
 A good text editor will provide
 
-  * efficient text editing commands (e.g., copy, paste, search and replace)
+* efficient text editing commands (e.g., copy, paste, search and replace)
 
-  * syntax highlighting, etc.
+* syntax highlighting, etc.
 
 Right now, an extremely popular text editor for coding is `VS Code <https://code.visualstudio.com/>`__.
 

--- a/source/rst/getting_started.rst
+++ b/source/rst/getting_started.rst
@@ -164,7 +164,7 @@ Either
 
 * open up a terminal and type ``jupyter notebook``
 
-    * Windows users should substitute "Anaconda command prompt" for "terminal" in the previous line.
+   * Windows users should substitute "Anaconda command prompt" for "terminal" in the previous line.
 
 If you use the second option, you will see something like this
 
@@ -237,15 +237,15 @@ The two modes are
 
 #. Edit mode
 
-    * Indicated by a green border around one cell, plus a blinking cursor
+   * Indicated by a green border around one cell, plus a blinking cursor
 
-    * Whatever you type appears as is in that cell
+   * Whatever you type appears as is in that cell
 
 #. Command mode
 
-    * The green border is replaced by a grey (or grey and blue) border
+   * The green border is replaced by a grey (or grey and blue) border
 
-    * Keystrokes are interpreted as commands --- for example, typing `b` adds a new cell below  the current one
+   * Keystrokes are interpreted as commands --- for example, typing `b` adds a new cell below  the current one
 
 
 To switch to
@@ -519,9 +519,9 @@ Nothing beats the power and efficiency of a good text editor for working with pr
 
 A good text editor will provide
 
-    * efficient text editing commands (e.g., copy, paste, search and replace)
+   * efficient text editing commands (e.g., copy, paste, search and replace)
 
-    * syntax highlighting, etc.
+   * syntax highlighting, etc.
 
 Right now, an extremely popular text editor for coding is `VS Code <https://code.visualstudio.com/>`__.
 
@@ -595,7 +595,7 @@ There are two main flavors of Git
 
 #. the various point-and-click GUI versions
 
-    * See, for example, the `GitHub version <https://desktop.github.com/>`_
+   * See, for example, the `GitHub version <https://desktop.github.com/>`_
 
 As the 1st task, try
 

--- a/source/rst/getting_started.rst
+++ b/source/rst/getting_started.rst
@@ -164,7 +164,7 @@ Either
 
 * open up a terminal and type ``jupyter notebook``
 
-   * Windows users should substitute "Anaconda command prompt" for "terminal" in the previous line.
+  * Windows users should substitute "Anaconda command prompt" for "terminal" in the previous line.
 
 If you use the second option, you will see something like this
 
@@ -519,9 +519,9 @@ Nothing beats the power and efficiency of a good text editor for working with pr
 
 A good text editor will provide
 
-   * efficient text editing commands (e.g., copy, paste, search and replace)
+  * efficient text editing commands (e.g., copy, paste, search and replace)
 
-   * syntax highlighting, etc.
+  * syntax highlighting, etc.
 
 Right now, an extremely popular text editor for coding is `VS Code <https://code.visualstudio.com/>`__.
 

--- a/source/rst/numba.rst
+++ b/source/rst/numba.rst
@@ -175,7 +175,7 @@ The basic idea is this:
 * Python is very flexible and hence we could call the function `qm` with many
   types.
 
-    * e.g., ``x0`` could be a NumPy array or a list, ``n`` could be an integer or a float, etc.
+   * e.g., ``x0`` could be a NumPy array or a list, ``n`` could be an integer or a float, etc.
 
 * This makes it hard to *pre*-compile the function.
 

--- a/source/rst/numba.rst
+++ b/source/rst/numba.rst
@@ -175,7 +175,7 @@ The basic idea is this:
 * Python is very flexible and hence we could call the function `qm` with many
   types.
 
-   * e.g., ``x0`` could be a NumPy array or a list, ``n`` could be an integer or a float, etc.
+  * e.g., ``x0`` could be a NumPy array or a list, ``n`` could be an integer or a float, etc.
 
 * This makes it hard to *pre*-compile the function.
 

--- a/source/rst/pandas.rst
+++ b/source/rst/pandas.rst
@@ -38,15 +38,15 @@ Just as `NumPy <http://www.numpy.org/>`_ provides the basic array data type plus
 
 #. endows them with methods that facilitate operations such as
 
-    * reading in data
+   * reading in data
 
-    * adjusting indices
+   * adjusting indices
 
-    * working with dates and time series
+   * working with dates and time series
 
-    * sorting, grouping, re-ordering and general data munging [#mung]_
+   * sorting, grouping, re-ordering and general data munging [#mung]_
 
-    * dealing with missing values, etc., etc.
+   * dealing with missing values, etc., etc.
 
 More sophisticated statistical functionality is left to other packages, such
 as `statsmodels <http://www.statsmodels.org/>`__ and `scikit-learn <http://scikit-learn.org/>`__, which are built on top of pandas.

--- a/source/rst/pandas.rst
+++ b/source/rst/pandas.rst
@@ -38,9 +38,9 @@ Just as `NumPy <http://www.numpy.org/>`_ provides the basic array data type plus
 
 #. endows them with methods that facilitate operations such as
 
-   * reading in data
+  * reading in data
 
-   * adjusting indices
+  * adjusting indices
 
    * working with dates and time series
 

--- a/source/rst/pandas.rst
+++ b/source/rst/pandas.rst
@@ -38,9 +38,9 @@ Just as `NumPy <http://www.numpy.org/>`_ provides the basic array data type plus
 
 #. endows them with methods that facilitate operations such as
 
-  * reading in data
+   * reading in data
 
-  * adjusting indices
+   * adjusting indices
 
    * working with dates and time series
 

--- a/source/rst/python_advanced_features.rst
+++ b/source/rst/python_advanced_features.rst
@@ -796,15 +796,15 @@ Here's what happens
 
 * The call ``f(x)``
 
-    * Creates a local namespace
+   * Creates a local namespace
 
-    * Adds ``x`` to local namespace, bound to ``[1]``
+   * Adds ``x`` to local namespace, bound to ``[1]``
 
-    * The list ``[1]`` is modified to ``[2]``
+   * The list ``[1]`` is modified to ``[2]``
 
-    * Returns the list ``[2]``
+   * Returns the list ``[2]``
 
-    * The local namespace is deallocated, and local ``x`` is lost
+   * The local namespace is deallocated, and local ``x`` is lost
 
 * Global ``x`` has been modified
 

--- a/source/rst/python_advanced_features.rst
+++ b/source/rst/python_advanced_features.rst
@@ -796,15 +796,15 @@ Here's what happens
 
 * The call ``f(x)``
 
-   * Creates a local namespace
+  * Creates a local namespace
 
-   * Adds ``x`` to local namespace, bound to ``[1]``
+  * Adds ``x`` to local namespace, bound to ``[1]``
 
-   * The list ``[1]`` is modified to ``[2]``
+  * The list ``[1]`` is modified to ``[2]``
 
-   * Returns the list ``[2]``
+  * Returns the list ``[2]``
 
-   * The local namespace is deallocated, and local ``x`` is lost
+  * The local namespace is deallocated, and local ``x`` is lost
 
 * Global ``x`` has been modified
 

--- a/source/rst/python_by_example.rst
+++ b/source/rst/python_by_example.rst
@@ -416,10 +416,10 @@ On the other hand, it takes a bit of care to get right, so please remember:
 
 * The line before the start of a code block always ends in a colon
 
-   * ``for i in range(10):``
-   * ``if x > y:``
-   * ``while x < 100:``
-   * etc., etc.
+  * ``for i in range(10):``
+  * ``if x > y:``
+  * ``while x < 100:``
+  * etc., etc.
 
 * All lines in a code block **must have the same amount of indentation**.
 

--- a/source/rst/python_by_example.rst
+++ b/source/rst/python_by_example.rst
@@ -416,10 +416,10 @@ On the other hand, it takes a bit of care to get right, so please remember:
 
 * The line before the start of a code block always ends in a colon
 
-    * ``for i in range(10):``
-    * ``if x > y:``
-    * ``while x < 100:``
-    * etc., etc.
+   * ``for i in range(10):``
+   * ``if x > y:``
+   * ``while x < 100:``
+   * etc., etc.
 
 * All lines in a code block **must have the same amount of indentation**.
 

--- a/source/rst/python_essentials.rst
+++ b/source/rst/python_essentials.rst
@@ -559,11 +559,11 @@ The rule is:
 
 * Expressions that evaluate to zero, empty sequences or containers (strings, lists, etc.) and ``None`` are all equivalent to ``False``.
 
-   * for example, ``[]`` and ``()`` are equivalent to ``False`` in an ``if`` clause
+  * for example, ``[]`` and ``()`` are equivalent to ``False`` in an ``if`` clause
 
 * All other values are equivalent to ``True``.
 
-   * for example, ``42`` is equivalent to ``True`` in an ``if`` clause
+  * for example, ``42`` is equivalent to ``True`` in an ``if`` clause
 
 
 

--- a/source/rst/python_essentials.rst
+++ b/source/rst/python_essentials.rst
@@ -559,11 +559,11 @@ The rule is:
 
 * Expressions that evaluate to zero, empty sequences or containers (strings, lists, etc.) and ``None`` are all equivalent to ``False``.
 
-    * for example, ``[]`` and ``()`` are equivalent to ``False`` in an ``if`` clause
+   * for example, ``[]`` and ``()`` are equivalent to ``False`` in an ``if`` clause
 
 * All other values are equivalent to ``True``.
 
-    * for example, ``42`` is equivalent to ``True`` in an ``if`` clause
+   * for example, ``42`` is equivalent to ``True`` in an ``if`` clause
 
 
 

--- a/source/rst/python_oop.rst
+++ b/source/rst/python_oop.rst
@@ -340,11 +340,11 @@ The rules for using ``self`` in creating a Class are that
 
 * Any instance data should be prepended with ``self``
 
-    * e.g., the ``earn`` method uses ``self.wealth`` rather than just ``wealth``
+   * e.g., the ``earn`` method uses ``self.wealth`` rather than just ``wealth``
 
 * A method defined within the code that defines the  class should have ``self`` as its first argument
 
-    * e.g., ``def earn(self, y)`` rather than just ``def earn(y)``
+   * e.g., ``def earn(self, y)`` rather than just ``def earn(y)``
 
 * Any method referenced within the class should be called as  ``self.method_name``
 
@@ -442,7 +442,7 @@ Some points of interest in the code are
 
 * The ``update`` method uses ``h`` to update capital as per :eq:`solow_lom`.
 
-    * Notice how inside ``update`` the reference to the local method ``h`` is ``self.h``.
+   * Notice how inside ``update`` the reference to the local method ``h`` is ``self.h``.
 
 The methods ``steady_state`` and ``generate_sequence`` are fairly self-explanatory
 

--- a/source/rst/python_oop.rst
+++ b/source/rst/python_oop.rst
@@ -340,11 +340,11 @@ The rules for using ``self`` in creating a Class are that
 
 * Any instance data should be prepended with ``self``
 
-   * e.g., the ``earn`` method uses ``self.wealth`` rather than just ``wealth``
+  * e.g., the ``earn`` method uses ``self.wealth`` rather than just ``wealth``
 
 * A method defined within the code that defines the  class should have ``self`` as its first argument
 
-   * e.g., ``def earn(self, y)`` rather than just ``def earn(y)``
+  * e.g., ``def earn(self, y)`` rather than just ``def earn(y)``
 
 * Any method referenced within the class should be called as  ``self.method_name``
 
@@ -442,7 +442,7 @@ Some points of interest in the code are
 
 * The ``update`` method uses ``h`` to update capital as per :eq:`solow_lom`.
 
-   * Notice how inside ``update`` the reference to the local method ``h`` is ``self.h``.
+  * Notice how inside ``update`` the reference to the local method ``h`` is ``self.h``.
 
 The methods ``steady_state`` and ``generate_sequence`` are fairly self-explanatory
 

--- a/source/rst/scipy.rst
+++ b/source/rst/scipy.rst
@@ -231,9 +231,9 @@ To understand the idea, recall the well-known game where
 
 * Player B asks if it's less than 50
 
-   * If yes, B asks if it's less than 25
+  * If yes, B asks if it's less than 25
 
-   * If no, B asks if it's less than 75
+  * If no, B asks if it's less than 75
 
 And so on.
 

--- a/source/rst/scipy.rst
+++ b/source/rst/scipy.rst
@@ -231,9 +231,9 @@ To understand the idea, recall the well-known game where
 
 * Player B asks if it's less than 50
 
-    * If yes, B asks if it's less than 25
+   * If yes, B asks if it's less than 25
 
-    * If no, B asks if it's less than 75
+   * If no, B asks if it's less than 75
 
 And so on.
 


### PR DESCRIPTION
This PR fixes incorrect `rst` for the myst conversion project for nested lists. 

`RST` requires `3 spaces`