### PR TITLE
[getting_started] fix spacing so RST doesn't insert blockquote

### DIFF
--- a/source/rst/getting_started.rst
+++ b/source/rst/getting_started.rst
@@ -429,25 +429,33 @@ One library we'll be using is `QuantEcon.py <http://quantecon.org/quantecon-py>`
 You can install `QuantEcon.py <http://quantecon.org/quantecon-py>`__ by
 starting Jupyter and typing
 
-``!conda install quantecon``
+.. code-block:: ipython3
+  
+    !conda install quantecon
 
 into a cell.
 
 Alternatively, you can type the following into a terminal
 
-``conda install quantecon``
+.. code-block:: bash
+
+    conda install quantecon
 
 More instructions can be found on the `library page <http://quantecon.org/quantecon-py>`__.
 
 To upgrade to the latest version, which you should do regularly, use
 
-``conda upgrade quantecon``
+.. code-block:: bash
+
+    conda upgrade quantecon
 
 Another library we will be using is `interpolation.py <https://github.com/EconForge/interpolation.py>`__.
 
 This can be installed by typing in Jupyter
 
-``!conda install -c conda-forge interpolation``
+.. code-block:: ipython3
+
+  !conda install -c conda-forge interpolation
 
 
 

--- a/source/rst/getting_started.rst
+++ b/source/rst/getting_started.rst
@@ -430,6 +430,7 @@ You can install `QuantEcon.py <http://quantecon.org/quantecon-py>`__ by
 starting Jupyter and typing
 
 .. code-block:: ipython3
+    :class: no-execute
   
     !conda install quantecon
 
@@ -438,6 +439,7 @@ into a cell.
 Alternatively, you can type the following into a terminal
 
 .. code-block:: bash
+    :class: no-execute
 
     conda install quantecon
 
@@ -446,6 +448,7 @@ More instructions can be found on the `library page <http://quantecon.org/quante
 To upgrade to the latest version, which you should do regularly, use
 
 .. code-block:: bash
+    :class: no-execute
 
     conda upgrade quantecon
 
@@ -454,8 +457,9 @@ Another library we will be using is `interpolation.py <https://github.com/EconFo
 This can be installed by typing in Jupyter
 
 .. code-block:: ipython3
+    :class: no-execute
 
-  !conda install -c conda-forge interpolation
+    !conda install -c conda-forge interpolation
 
 
 

--- a/source/rst/getting_started.rst
+++ b/source/rst/getting_started.rst
@@ -429,25 +429,25 @@ One library we'll be using is `QuantEcon.py <http://quantecon.org/quantecon-py>`
 You can install `QuantEcon.py <http://quantecon.org/quantecon-py>`__ by
 starting Jupyter and typing
 
-    ``!conda install quantecon``
+``!conda install quantecon``
 
 into a cell.
 
 Alternatively, you can type the following into a terminal
 
-    ``conda install quantecon``
+``conda install quantecon``
 
 More instructions can be found on the `library page <http://quantecon.org/quantecon-py>`__.
 
 To upgrade to the latest version, which you should do regularly, use
 
-    ``conda upgrade quantecon``
+``conda upgrade quantecon``
 
 Another library we will be using is `interpolation.py <https://github.com/EconForge/interpolation.py>`__.
 
 This can be installed by typing in Jupyter
 
-    ``!conda install -c conda-forge interpolation``
+``!conda install -c conda-forge interpolation``
 
 
 


### PR DESCRIPTION
This PR adjusts RST spacing to prevent interpretation of a `blockquote` from indentation. 